### PR TITLE
Fix E2E tests to run in isolated mode and exit automatically

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,6 +71,6 @@ unit-tests:
 	done
 
 e2e-tests:
-	docker compose -f docker-compose.yml -f tests/e2e/docker-compose.test.yml up --build --exit-code-from e2e-tests
+	docker compose -f tests/e2e/docker-compose.e2e.yml up --build --abort-on-container-exit --exit-code-from e2e-tests
 
 test-all: unit-tests e2e-tests

--- a/tests/e2e/docker-compose.e2e.yml
+++ b/tests/e2e/docker-compose.e2e.yml
@@ -1,0 +1,184 @@
+version: "3.9"
+
+services:
+  redis-service:
+    image: public.ecr.aws/docker/library/redis:7-alpine
+    restart: unless-stopped
+    ports:
+      - "6379:6379"
+    volumes:
+      - redis-data:/data
+    networks:
+      - taskmanager-net
+
+  nats:
+    image: public.ecr.aws/docker/library/nats:2.10.10
+    command: ["-c", "/etc/nats/nats.conf"]
+    restart: unless-stopped
+    volumes:
+      - ../../configs/nats.conf:/etc/nats/nats.conf:ro
+      - nats-data:/data
+    ports:
+      - "4222:4222"
+      - "8222:8222"
+    networks:
+      - taskmanager-net
+
+  envoy:
+    image: envoyproxy/envoy:v1.30.2
+    command: ["-c", "/etc/envoy/envoy.yaml", "--log-level", "info"]
+    restart: unless-stopped
+    volumes:
+      - ../../configs/envoy.yaml:/etc/envoy/envoy.yaml:ro
+    ports:
+      - "50051:50051"
+      - "9901:9901"
+    depends_on:
+      - taskmanager-service
+    networks:
+      - taskmanager-net
+
+  taskmanager-service:
+    build:
+      context: ../../
+      dockerfile: server/Dockerfile
+    restart: unless-stopped
+    environment:
+      - REDIS_ADDR=redis-service:6379
+      - OTEL_EXPORTER_OTLP_ENDPOINT=127.0.0.1:4317
+    depends_on:
+      - notifier
+      - redis-service
+    networks:
+      - taskmanager-net
+
+  ingest:
+    build:
+      context: ../../
+      dockerfile: ingest/Dockerfile
+    restart: unless-stopped
+    environment:
+      - REDIS_ADDR=redis-service:6379
+      - ENRICHER_URL=http://enricher:8080/enrich
+      - OTEL_EXPORTER_OTLP_ENDPOINT=127.0.0.1:4317
+    depends_on:
+      - redis-service
+      - enricher
+    networks:
+      - taskmanager-net
+
+  enricher:
+    build:
+      context: ../../
+      dockerfile: enricher/Dockerfile
+    restart: unless-stopped
+    environment:
+      - OTEL_EXPORTER_OTLP_ENDPOINT=127.0.0.1:4317
+    networks:
+      - taskmanager-net
+
+  scheduler:
+    build:
+      context: ../../
+      dockerfile: scheduler/Dockerfile
+    restart: unless-stopped
+    environment:
+      - REDIS_ADDR=redis-service:6379
+      - OTEL_EXPORTER_OTLP_ENDPOINT=127.0.0.1:4317
+    depends_on:
+      - redis-service
+    networks:
+      - taskmanager-net
+
+  worker:
+    build:
+      context: ../../
+      dockerfile: worker/Dockerfile
+    restart: unless-stopped
+    environment:
+      - REDIS_ADDR=redis-service:6379
+      - WORKER_COUNT=4
+      - WORKER_FAIL_RATE=0.05
+      - OTEL_EXPORTER_OTLP_ENDPOINT=127.0.0.1:4317
+    depends_on:
+      - redis-service
+    networks:
+      - taskmanager-net
+
+  notifier:
+    build:
+      context: ../../
+      dockerfile: notifier/Dockerfile
+    restart: unless-stopped
+    environment:
+      - REDIS_ADDR=redis-service:6379
+      - OTEL_EXPORTER_OTLP_ENDPOINT=127.0.0.1:4317
+    depends_on:
+      - redis-service
+    networks:
+      - taskmanager-net
+
+  result-store:
+    build:
+      context: ../../
+      dockerfile: result-store/Dockerfile
+    restart: unless-stopped
+    environment:
+      - REDIS_ADDR=redis-service:6379
+      - RESULT_STORE_PORT=8082
+      - OTEL_EXPORTER_OTLP_ENDPOINT=127.0.0.1:4317
+    ports:
+      - "8082:8082"
+    depends_on:
+      - redis-service
+    networks:
+      - taskmanager-net
+
+  audit:
+    build:
+      context: ../../
+      dockerfile: audit/Dockerfile
+    restart: unless-stopped
+    environment:
+      - REDIS_ADDR=redis-service:6379
+      - OTEL_EXPORTER_OTLP_ENDPOINT=127.0.0.1:4317
+    depends_on:
+      - redis-service
+    networks:
+      - taskmanager-net
+
+  deadletter:
+    build:
+      context: ../../
+      dockerfile: deadletter/Dockerfile
+    restart: unless-stopped
+    environment:
+      - REDIS_ADDR=redis-service:6379
+      - OTEL_EXPORTER_OTLP_ENDPOINT=127.0.0.1:4317
+    depends_on:
+      - redis-service
+    networks:
+      - taskmanager-net
+
+  e2e-tests:
+    build:
+      context: ../../
+      dockerfile: tests/e2e/Dockerfile
+    environment:
+      - TASKMANAGER_ADDR=envoy:50051
+    depends_on:
+      - envoy
+    networks:
+      - taskmanager-net
+
+networks:
+  taskmanager-net:
+    name: taskmanager-net
+    driver: bridge
+    ipam:
+      config:
+        - subnet: 172.28.0.0/16
+
+volumes:
+  redis-data:
+  nats-data:

--- a/tests/e2e/docker-compose.test.yml
+++ b/tests/e2e/docker-compose.test.yml
@@ -1,3 +1,0 @@
-services:
-  producer:
-    entrypoint: ["/bin/sh", "-c", "exit 0"]


### PR DESCRIPTION
This PR optimizes the End-to-End (E2E) testing workflow. Previously, E2E tests relied on the main `docker-compose.yml`, which started the entire application stack including heavy observability and visualization services, and did not automatically shut down after execution.

Changes:
1.  **Dedicated Compose File:** Introduced `tests/e2e/docker-compose.e2e.yml` which includes only the essential services for functional testing (NATS, Redis, Envoy, and Go microservices).
2.  **Resource Optimization:** Excluded unnecessary services like Prometheus, Grafana, Tempo, and Visualizer.
3.  **Automatic Shutdown:** Updated the `make e2e-tests` command to use `docker compose ... --abort-on-container-exit --exit-code-from e2e-tests`. This ensures the test runner drives the lifecycle of the environment.
4.  **Configuration:** Adjusted build contexts to `../../` and set `OTEL_EXPORTER_OTLP_ENDPOINT` to `127.0.0.1:4317` to prevent connection errors in the absence of the OTEL collector.

---
*PR created automatically by Jules for task [1431144589149005534](https://jules.google.com/task/1431144589149005534) started by @maciekb2*