### PR TITLE
Fix E2E tests CI failure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
           done
 
       - name: Run E2E Tests
-        run: docker compose -f docker-compose.yml -f tests/e2e/docker-compose.test.yml up --build --exit-code-from e2e-tests
+        run: docker compose -f tests/e2e/docker-compose.e2e.yml up --build --exit-code-from e2e-tests
 
       - name: Cleanup
         if: always()


### PR DESCRIPTION
Fixed the CI workflow to point to the correct `tests/e2e/docker-compose.e2e.yml` file instead of the non-existent `docker-compose.test.yml`. Also removed the inclusion of `docker-compose.yml` to prevent configuration conflicts, aligning CI with the local `make e2e-tests` command.

---
*PR created automatically by Jules for task [5451326627627100963](https://jules.google.com/task/5451326627627100963) started by @maciekb2*