### PR TITLE
Fix E2E Test Network and Telemetry Configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,24 +14,27 @@
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
 
-<<<<<<< HEAD
 # Dependency directories (remove the comment below to include it)
 # vendor/
 
-=======
->>>>>>> dev
 # Go workspace file
 go.work
 go.work.sum
 
 # env file
 .env
-<<<<<<< HEAD
-=======
 
 # Pliki binarne
 server/server
 client/client
+enricher/enricher
+worker/worker
+ingest/ingest
+scheduler/scheduler
+notifier/notifier
+result-store/result-store
+audit/audit
+deadletter/deadletter
 
 # Tymczasowe pliki systemowe
 *.DS_Store
@@ -39,5 +42,3 @@ client/client
 
 # Katalogi Go
 /vendor
-
->>>>>>> dev

--- a/audit/telemetry.go
+++ b/audit/telemetry.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"strings"
 
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"google.golang.org/grpc"
@@ -70,6 +71,12 @@ func serverOpts() []grpc.ServerOption {
 
 func otelEndpoint() string {
 	if endpoint := os.Getenv("OTEL_EXPORTER_OTLP_ENDPOINT"); endpoint != "" {
+		if strings.HasPrefix(endpoint, "http://") {
+			return strings.TrimPrefix(endpoint, "http://")
+		}
+		if strings.HasPrefix(endpoint, "https://") {
+			return strings.TrimPrefix(endpoint, "https://")
+		}
 		return endpoint
 	}
 	return "tempo:4317"

--- a/client/telemetry.go
+++ b/client/telemetry.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"strings"
 
 	"google.golang.org/grpc"
 
@@ -71,6 +72,12 @@ func dialOpts() []grpc.DialOption {
 
 func otelEndpoint() string {
 	if endpoint := os.Getenv("OTEL_EXPORTER_OTLP_ENDPOINT"); endpoint != "" {
+		if strings.HasPrefix(endpoint, "http://") {
+			return strings.TrimPrefix(endpoint, "http://")
+		}
+		if strings.HasPrefix(endpoint, "https://") {
+			return strings.TrimPrefix(endpoint, "https://")
+		}
 		return endpoint
 	}
 	return "tempo:4317"

--- a/deadletter/telemetry.go
+++ b/deadletter/telemetry.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"strings"
 
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"google.golang.org/grpc"
@@ -70,6 +71,12 @@ func serverOpts() []grpc.ServerOption {
 
 func otelEndpoint() string {
 	if endpoint := os.Getenv("OTEL_EXPORTER_OTLP_ENDPOINT"); endpoint != "" {
+		if strings.HasPrefix(endpoint, "http://") {
+			return strings.TrimPrefix(endpoint, "http://")
+		}
+		if strings.HasPrefix(endpoint, "https://") {
+			return strings.TrimPrefix(endpoint, "https://")
+		}
 		return endpoint
 	}
 	return "tempo:4317"

--- a/enricher/telemetry.go
+++ b/enricher/telemetry.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"strings"
 
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"google.golang.org/grpc"
@@ -70,6 +71,12 @@ func serverOpts() []grpc.ServerOption {
 
 func otelEndpoint() string {
 	if endpoint := os.Getenv("OTEL_EXPORTER_OTLP_ENDPOINT"); endpoint != "" {
+		if strings.HasPrefix(endpoint, "http://") {
+			return strings.TrimPrefix(endpoint, "http://")
+		}
+		if strings.HasPrefix(endpoint, "https://") {
+			return strings.TrimPrefix(endpoint, "https://")
+		}
 		return endpoint
 	}
 	return "tempo:4317"

--- a/ingest/telemetry.go
+++ b/ingest/telemetry.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"strings"
 
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"google.golang.org/grpc"
@@ -70,6 +71,12 @@ func serverOpts() []grpc.ServerOption {
 
 func otelEndpoint() string {
 	if endpoint := os.Getenv("OTEL_EXPORTER_OTLP_ENDPOINT"); endpoint != "" {
+		if strings.HasPrefix(endpoint, "http://") {
+			return strings.TrimPrefix(endpoint, "http://")
+		}
+		if strings.HasPrefix(endpoint, "https://") {
+			return strings.TrimPrefix(endpoint, "https://")
+		}
 		return endpoint
 	}
 	return "tempo:4317"

--- a/notifier/telemetry.go
+++ b/notifier/telemetry.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"strings"
 
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"google.golang.org/grpc"
@@ -70,6 +71,12 @@ func serverOpts() []grpc.ServerOption {
 
 func otelEndpoint() string {
 	if endpoint := os.Getenv("OTEL_EXPORTER_OTLP_ENDPOINT"); endpoint != "" {
+		if strings.HasPrefix(endpoint, "http://") {
+			return strings.TrimPrefix(endpoint, "http://")
+		}
+		if strings.HasPrefix(endpoint, "https://") {
+			return strings.TrimPrefix(endpoint, "https://")
+		}
 		return endpoint
 	}
 	return "tempo:4317"

--- a/result-store/telemetry.go
+++ b/result-store/telemetry.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"strings"
 
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"google.golang.org/grpc"
@@ -70,6 +71,12 @@ func serverOpts() []grpc.ServerOption {
 
 func otelEndpoint() string {
 	if endpoint := os.Getenv("OTEL_EXPORTER_OTLP_ENDPOINT"); endpoint != "" {
+		if strings.HasPrefix(endpoint, "http://") {
+			return strings.TrimPrefix(endpoint, "http://")
+		}
+		if strings.HasPrefix(endpoint, "https://") {
+			return strings.TrimPrefix(endpoint, "https://")
+		}
 		return endpoint
 	}
 	return "tempo:4317"

--- a/scheduler/telemetry.go
+++ b/scheduler/telemetry.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"strings"
 
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"google.golang.org/grpc"
@@ -70,6 +71,12 @@ func serverOpts() []grpc.ServerOption {
 
 func otelEndpoint() string {
 	if endpoint := os.Getenv("OTEL_EXPORTER_OTLP_ENDPOINT"); endpoint != "" {
+		if strings.HasPrefix(endpoint, "http://") {
+			return strings.TrimPrefix(endpoint, "http://")
+		}
+		if strings.HasPrefix(endpoint, "https://") {
+			return strings.TrimPrefix(endpoint, "https://")
+		}
 		return endpoint
 	}
 	return "tempo:4317"

--- a/server/telemetry.go
+++ b/server/telemetry.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 	"os"
+	"strings"
 
 	"github.com/maciekb2/task-manager/pkg/logger"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
@@ -70,6 +71,12 @@ func serverOpts() []grpc.ServerOption {
 
 func otelEndpoint() string {
 	if endpoint := os.Getenv("OTEL_EXPORTER_OTLP_ENDPOINT"); endpoint != "" {
+		if strings.HasPrefix(endpoint, "http://") {
+			return strings.TrimPrefix(endpoint, "http://")
+		}
+		if strings.HasPrefix(endpoint, "https://") {
+			return strings.TrimPrefix(endpoint, "https://")
+		}
 		return endpoint
 	}
 	return "tempo:4317"

--- a/tests/e2e/docker-compose.e2e.yml
+++ b/tests/e2e/docker-compose.e2e.yml
@@ -45,7 +45,7 @@ services:
     restart: unless-stopped
     environment:
       - REDIS_ADDR=redis-service:6379
-      - OTEL_EXPORTER_OTLP_ENDPOINT=127.0.0.1:4317
+      - OTEL_EXPORTER_OTLP_ENDPOINT=http://127.0.0.1:4317
     depends_on:
       - notifier
       - redis-service
@@ -60,7 +60,7 @@ services:
     environment:
       - REDIS_ADDR=redis-service:6379
       - ENRICHER_URL=http://enricher:8080/enrich
-      - OTEL_EXPORTER_OTLP_ENDPOINT=127.0.0.1:4317
+      - OTEL_EXPORTER_OTLP_ENDPOINT=http://127.0.0.1:4317
     depends_on:
       - redis-service
       - enricher
@@ -73,7 +73,7 @@ services:
       dockerfile: enricher/Dockerfile
     restart: unless-stopped
     environment:
-      - OTEL_EXPORTER_OTLP_ENDPOINT=127.0.0.1:4317
+      - OTEL_EXPORTER_OTLP_ENDPOINT=http://127.0.0.1:4317
     networks:
       - taskmanager-net
 
@@ -84,7 +84,7 @@ services:
     restart: unless-stopped
     environment:
       - REDIS_ADDR=redis-service:6379
-      - OTEL_EXPORTER_OTLP_ENDPOINT=127.0.0.1:4317
+      - OTEL_EXPORTER_OTLP_ENDPOINT=http://127.0.0.1:4317
     depends_on:
       - redis-service
     networks:
@@ -99,7 +99,7 @@ services:
       - REDIS_ADDR=redis-service:6379
       - WORKER_COUNT=4
       - WORKER_FAIL_RATE=0.05
-      - OTEL_EXPORTER_OTLP_ENDPOINT=127.0.0.1:4317
+      - OTEL_EXPORTER_OTLP_ENDPOINT=http://127.0.0.1:4317
     depends_on:
       - redis-service
     networks:
@@ -112,7 +112,7 @@ services:
     restart: unless-stopped
     environment:
       - REDIS_ADDR=redis-service:6379
-      - OTEL_EXPORTER_OTLP_ENDPOINT=127.0.0.1:4317
+      - OTEL_EXPORTER_OTLP_ENDPOINT=http://127.0.0.1:4317
     depends_on:
       - redis-service
     networks:
@@ -126,7 +126,7 @@ services:
     environment:
       - REDIS_ADDR=redis-service:6379
       - RESULT_STORE_PORT=8082
-      - OTEL_EXPORTER_OTLP_ENDPOINT=127.0.0.1:4317
+      - OTEL_EXPORTER_OTLP_ENDPOINT=http://127.0.0.1:4317
     ports:
       - "8082:8082"
     depends_on:
@@ -141,7 +141,7 @@ services:
     restart: unless-stopped
     environment:
       - REDIS_ADDR=redis-service:6379
-      - OTEL_EXPORTER_OTLP_ENDPOINT=127.0.0.1:4317
+      - OTEL_EXPORTER_OTLP_ENDPOINT=http://127.0.0.1:4317
     depends_on:
       - redis-service
     networks:
@@ -154,7 +154,7 @@ services:
     restart: unless-stopped
     environment:
       - REDIS_ADDR=redis-service:6379
-      - OTEL_EXPORTER_OTLP_ENDPOINT=127.0.0.1:4317
+      - OTEL_EXPORTER_OTLP_ENDPOINT=http://127.0.0.1:4317
     depends_on:
       - redis-service
     networks:
@@ -173,11 +173,7 @@ services:
 
 networks:
   taskmanager-net:
-    name: taskmanager-net
     driver: bridge
-    ipam:
-      config:
-        - subnet: 172.28.0.0/16
 
 volumes:
   redis-data:

--- a/worker/telemetry.go
+++ b/worker/telemetry.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"strings"
 
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"google.golang.org/grpc"
@@ -70,6 +71,12 @@ func serverOpts() []grpc.ServerOption {
 
 func otelEndpoint() string {
 	if endpoint := os.Getenv("OTEL_EXPORTER_OTLP_ENDPOINT"); endpoint != "" {
+		if strings.HasPrefix(endpoint, "http://") {
+			return strings.TrimPrefix(endpoint, "http://")
+		}
+		if strings.HasPrefix(endpoint, "https://") {
+			return strings.TrimPrefix(endpoint, "https://")
+		}
 		return endpoint
 	}
 	return "tempo:4317"


### PR DESCRIPTION
Fixed URL parsing errors in the enricher and other services by ensuring the OpenTelemetry endpoint has a scheme for the internal logger but is stripped for the gRPC exporter. Also resolved 'network not found' errors in E2E tests by removing static network configuration, allowing Docker Compose to manage network names dynamically.

---
*PR created automatically by Jules for task [2788997877700251064](https://jules.google.com/task/2788997877700251064) started by @maciekb2*