### PR TITLE
Fix telemetry URL parsing and isolate CI E2E tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,8 +30,8 @@ jobs:
           done
 
       - name: Run E2E Tests
-        run: docker compose -f tests/e2e/docker-compose.e2e.yml up --build --exit-code-from e2e-tests
+        run: docker compose -p "e2e-ci-${{ github.run_id }}" -f tests/e2e/docker-compose.e2e.yml up --build --exit-code-from e2e-tests
 
       - name: Cleanup
         if: always()
-        run: docker compose down -v
+        run: docker compose -p "e2e-ci-${{ github.run_id }}" -f tests/e2e/docker-compose.e2e.yml down -v

--- a/Makefile
+++ b/Makefile
@@ -71,6 +71,6 @@ unit-tests:
 	done
 
 e2e-tests:
-	docker compose -f tests/e2e/docker-compose.e2e.yml up --build --abort-on-container-exit --exit-code-from e2e-tests
+	docker compose -p taskmanager-e2e -f tests/e2e/docker-compose.e2e.yml up --build --abort-on-container-exit --exit-code-from e2e-tests
 
 test-all: unit-tests e2e-tests

--- a/audit/telemetry.go
+++ b/audit/telemetry.go
@@ -5,7 +5,6 @@ import (
 	"log"
 	"net/http"
 	"os"
-	"strings"
 
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"google.golang.org/grpc"
@@ -71,12 +70,6 @@ func serverOpts() []grpc.ServerOption {
 
 func otelEndpoint() string {
 	if endpoint := os.Getenv("OTEL_EXPORTER_OTLP_ENDPOINT"); endpoint != "" {
-		if strings.HasPrefix(endpoint, "http://") {
-			return strings.TrimPrefix(endpoint, "http://")
-		}
-		if strings.HasPrefix(endpoint, "https://") {
-			return strings.TrimPrefix(endpoint, "https://")
-		}
 		return endpoint
 	}
 	return "tempo:4317"

--- a/client/telemetry.go
+++ b/client/telemetry.go
@@ -5,7 +5,6 @@ import (
 	"log"
 	"net/http"
 	"os"
-	"strings"
 
 	"google.golang.org/grpc"
 
@@ -72,12 +71,6 @@ func dialOpts() []grpc.DialOption {
 
 func otelEndpoint() string {
 	if endpoint := os.Getenv("OTEL_EXPORTER_OTLP_ENDPOINT"); endpoint != "" {
-		if strings.HasPrefix(endpoint, "http://") {
-			return strings.TrimPrefix(endpoint, "http://")
-		}
-		if strings.HasPrefix(endpoint, "https://") {
-			return strings.TrimPrefix(endpoint, "https://")
-		}
 		return endpoint
 	}
 	return "tempo:4317"

--- a/deadletter/telemetry.go
+++ b/deadletter/telemetry.go
@@ -5,7 +5,6 @@ import (
 	"log"
 	"net/http"
 	"os"
-	"strings"
 
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"google.golang.org/grpc"
@@ -71,12 +70,6 @@ func serverOpts() []grpc.ServerOption {
 
 func otelEndpoint() string {
 	if endpoint := os.Getenv("OTEL_EXPORTER_OTLP_ENDPOINT"); endpoint != "" {
-		if strings.HasPrefix(endpoint, "http://") {
-			return strings.TrimPrefix(endpoint, "http://")
-		}
-		if strings.HasPrefix(endpoint, "https://") {
-			return strings.TrimPrefix(endpoint, "https://")
-		}
 		return endpoint
 	}
 	return "tempo:4317"

--- a/enricher/telemetry.go
+++ b/enricher/telemetry.go
@@ -5,7 +5,6 @@ import (
 	"log"
 	"net/http"
 	"os"
-	"strings"
 
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"google.golang.org/grpc"
@@ -71,12 +70,6 @@ func serverOpts() []grpc.ServerOption {
 
 func otelEndpoint() string {
 	if endpoint := os.Getenv("OTEL_EXPORTER_OTLP_ENDPOINT"); endpoint != "" {
-		if strings.HasPrefix(endpoint, "http://") {
-			return strings.TrimPrefix(endpoint, "http://")
-		}
-		if strings.HasPrefix(endpoint, "https://") {
-			return strings.TrimPrefix(endpoint, "https://")
-		}
 		return endpoint
 	}
 	return "tempo:4317"

--- a/ingest/telemetry.go
+++ b/ingest/telemetry.go
@@ -5,7 +5,6 @@ import (
 	"log"
 	"net/http"
 	"os"
-	"strings"
 
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"google.golang.org/grpc"
@@ -71,12 +70,6 @@ func serverOpts() []grpc.ServerOption {
 
 func otelEndpoint() string {
 	if endpoint := os.Getenv("OTEL_EXPORTER_OTLP_ENDPOINT"); endpoint != "" {
-		if strings.HasPrefix(endpoint, "http://") {
-			return strings.TrimPrefix(endpoint, "http://")
-		}
-		if strings.HasPrefix(endpoint, "https://") {
-			return strings.TrimPrefix(endpoint, "https://")
-		}
 		return endpoint
 	}
 	return "tempo:4317"

--- a/notifier/telemetry.go
+++ b/notifier/telemetry.go
@@ -5,7 +5,6 @@ import (
 	"log"
 	"net/http"
 	"os"
-	"strings"
 
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"google.golang.org/grpc"
@@ -71,12 +70,6 @@ func serverOpts() []grpc.ServerOption {
 
 func otelEndpoint() string {
 	if endpoint := os.Getenv("OTEL_EXPORTER_OTLP_ENDPOINT"); endpoint != "" {
-		if strings.HasPrefix(endpoint, "http://") {
-			return strings.TrimPrefix(endpoint, "http://")
-		}
-		if strings.HasPrefix(endpoint, "https://") {
-			return strings.TrimPrefix(endpoint, "https://")
-		}
 		return endpoint
 	}
 	return "tempo:4317"

--- a/result-store/telemetry.go
+++ b/result-store/telemetry.go
@@ -5,7 +5,6 @@ import (
 	"log"
 	"net/http"
 	"os"
-	"strings"
 
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"google.golang.org/grpc"
@@ -71,12 +70,6 @@ func serverOpts() []grpc.ServerOption {
 
 func otelEndpoint() string {
 	if endpoint := os.Getenv("OTEL_EXPORTER_OTLP_ENDPOINT"); endpoint != "" {
-		if strings.HasPrefix(endpoint, "http://") {
-			return strings.TrimPrefix(endpoint, "http://")
-		}
-		if strings.HasPrefix(endpoint, "https://") {
-			return strings.TrimPrefix(endpoint, "https://")
-		}
 		return endpoint
 	}
 	return "tempo:4317"

--- a/scheduler/telemetry.go
+++ b/scheduler/telemetry.go
@@ -5,7 +5,6 @@ import (
 	"log"
 	"net/http"
 	"os"
-	"strings"
 
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"google.golang.org/grpc"
@@ -71,12 +70,6 @@ func serverOpts() []grpc.ServerOption {
 
 func otelEndpoint() string {
 	if endpoint := os.Getenv("OTEL_EXPORTER_OTLP_ENDPOINT"); endpoint != "" {
-		if strings.HasPrefix(endpoint, "http://") {
-			return strings.TrimPrefix(endpoint, "http://")
-		}
-		if strings.HasPrefix(endpoint, "https://") {
-			return strings.TrimPrefix(endpoint, "https://")
-		}
 		return endpoint
 	}
 	return "tempo:4317"

--- a/server/telemetry.go
+++ b/server/telemetry.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"net/http"
 	"os"
-	"strings"
 
 	"github.com/maciekb2/task-manager/pkg/logger"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
@@ -71,12 +70,6 @@ func serverOpts() []grpc.ServerOption {
 
 func otelEndpoint() string {
 	if endpoint := os.Getenv("OTEL_EXPORTER_OTLP_ENDPOINT"); endpoint != "" {
-		if strings.HasPrefix(endpoint, "http://") {
-			return strings.TrimPrefix(endpoint, "http://")
-		}
-		if strings.HasPrefix(endpoint, "https://") {
-			return strings.TrimPrefix(endpoint, "https://")
-		}
 		return endpoint
 	}
 	return "tempo:4317"

--- a/worker/telemetry.go
+++ b/worker/telemetry.go
@@ -5,7 +5,6 @@ import (
 	"log"
 	"net/http"
 	"os"
-	"strings"
 
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"google.golang.org/grpc"
@@ -71,12 +70,6 @@ func serverOpts() []grpc.ServerOption {
 
 func otelEndpoint() string {
 	if endpoint := os.Getenv("OTEL_EXPORTER_OTLP_ENDPOINT"); endpoint != "" {
-		if strings.HasPrefix(endpoint, "http://") {
-			return strings.TrimPrefix(endpoint, "http://")
-		}
-		if strings.HasPrefix(endpoint, "https://") {
-			return strings.TrimPrefix(endpoint, "https://")
-		}
 		return endpoint
 	}
 	return "tempo:4317"


### PR DESCRIPTION
This PR addresses two issues:
1.  **Telemetry Parsing Error:** The `enricher` and other services were logging `parse "127.0.0.1:4317": first path segment in URL cannot contain colon`. This was caused by the application logic stripping the `http://` scheme from the OTel endpoint environment variable. Newer OTel libraries (or internal validation) require a valid URL structure or scheme when parsing. The fix removes the stripping logic, allowing the full URL (e.g., `http://127.0.0.1:4317`) to be passed.
2.  **CI/Network Instability:** The E2E tests were failing with `network not found` errors, likely due to conflicts when running on a shared host or parallel CI jobs using the default project name. The fix enforces unique project names in CI (`e2e-ci-<run_id>`) and a specific project name for local makefile runs (`taskmanager-e2e`).


---
*PR created automatically by Jules for task [1819143649632544948](https://jules.google.com/task/1819143649632544948) started by @maciekb2*