### PR TITLE
chore: Add tests for pkg/logger and pkg/bus

### DIFF
--- a/pkg/bus/bus_test.go
+++ b/pkg/bus/bus_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/nats-io/nats.go"
 	"github.com/stretchr/testify/assert"
 	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/propagation"
 	"go.opentelemetry.io/otel/trace"
 )
@@ -214,4 +215,24 @@ func TestCloneHeaders(t *testing.T) {
 	if cloned["Key1"][0] == "Modified" {
 		t.Error("cloneHeaders did not perform deep copy")
 	}
+}
+
+func TestMessageAttributes(t *testing.T) {
+	msg := &nats.Msg{
+		Subject: "test.subject",
+		Data:    []byte("data"),
+	}
+
+	attrs := MessageAttributes(msg)
+
+	// Expect at least subject
+	assert.NotEmpty(t, attrs)
+
+	foundSubject := false
+	for _, kv := range attrs {
+		if kv.Key == attribute.Key(AttrMessageSubject) && kv.Value.AsString() == "test.subject" {
+			foundSubject = true
+		}
+	}
+	assert.True(t, foundSubject, "expected subject attribute")
 }

--- a/pkg/logger/logger_test.go
+++ b/pkg/logger/logger_test.go
@@ -1,0 +1,71 @@
+package logger
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"log/slog"
+	"strings"
+	"testing"
+
+	"go.opentelemetry.io/otel/trace"
+)
+
+func TestWithContext(t *testing.T) {
+	// Setup trace
+	traceID, _ := trace.TraceIDFromHex("4bf92f3577b34da6a3ce929d0e0e4736")
+	spanID, _ := trace.SpanIDFromHex("00f067aa0ba902b7")
+	spanContext := trace.NewSpanContext(trace.SpanContextConfig{
+		TraceID:    traceID,
+		SpanID:     spanID,
+		TraceFlags: trace.FlagsSampled,
+	})
+	ctx := trace.ContextWithSpanContext(context.Background(), spanContext)
+
+	// Capture output
+	var buf bytes.Buffer
+	handler := slog.NewJSONHandler(&buf, nil)
+	original := slog.Default()
+	defer slog.SetDefault(original)
+	slog.SetDefault(slog.New(handler))
+
+	// Execute
+	log := WithContext(ctx)
+	log.Info("test message")
+
+	// Verify
+	output := buf.String()
+	if !strings.Contains(output, "trace_id") {
+		t.Error("expected trace_id in log output")
+	}
+	if !strings.Contains(output, "4bf92f3577b34da6a3ce929d0e0e4736") {
+		t.Errorf("expected specific trace ID, got: %s", output)
+	}
+}
+
+func TestError(t *testing.T) {
+	var buf bytes.Buffer
+	handler := slog.NewJSONHandler(&buf, nil)
+	original := slog.Default()
+	defer slog.SetDefault(original)
+	slog.SetDefault(slog.New(handler))
+
+	err := errors.New("something went wrong")
+	Error("operation failed", err, "key", "value")
+
+	output := buf.String()
+	if !strings.Contains(output, "operation failed") {
+		t.Error("expected message in output")
+	}
+	if !strings.Contains(output, "something went wrong") {
+		t.Error("expected error message in output")
+	}
+	if !strings.Contains(output, "\"key\":\"value\"") {
+		t.Error("expected extra args in output")
+	}
+}
+
+func TestSetup(t *testing.T) {
+	// Just verify it doesn't panic
+	Setup("test-service")
+}


### PR DESCRIPTION
Added unit tests for `pkg/logger` to verify trace ID injection and error handling.
Enhanced `pkg/bus` tests to verify OpenTelemetry attribute extraction from NATS messages.
This improves test coverage for shared libraries used across all microservices.

---
*PR created automatically by Jules for task [2372540264693752537](https://jules.google.com/task/2372540264693752537) started by @maciekb2*