### PR TITLE
Add worker resilience and flow contract tests

### DIFF
--- a/pkg/flow/json_test.go
+++ b/pkg/flow/json_test.go
@@ -1,0 +1,80 @@
+package flow
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestTaskEnvelope_JSON(t *testing.T) {
+	// Case 1: With all fields
+	t1 := TaskEnvelope{
+		TaskID:      "1",
+		TraceParent: "trace-1",
+		Category:    "high",
+		Score:       100,
+	}
+	b1, err := json.Marshal(t1)
+	if err != nil {
+		t.Fatalf("Marshal failed: %v", err)
+	}
+	s1 := string(b1)
+	if !strings.Contains(s1, "traceparent") {
+		t.Error("Expected traceparent field")
+	}
+	if !strings.Contains(s1, "category") {
+		t.Error("Expected category field")
+	}
+	if !strings.Contains(s1, "score") {
+		t.Error("Expected score field")
+	}
+
+	// Case 2: Omitted fields
+	t2 := TaskEnvelope{
+		TaskID: "2",
+	}
+	b2, err := json.Marshal(t2)
+	if err != nil {
+		t.Fatalf("Marshal failed: %v", err)
+	}
+	s2 := string(b2)
+	if strings.Contains(s2, "traceparent") {
+		t.Error("Expected traceparent to be omitted")
+	}
+	if strings.Contains(s2, "category") {
+		t.Error("Expected category to be omitted")
+	}
+	if strings.Contains(s2, "score") {
+		t.Error("Expected score to be omitted")
+	}
+}
+
+func TestResultEnvelope_JSON(t *testing.T) {
+	// Case 1: With Latency
+	r1 := ResultEnvelope{
+		Result:    200,
+		LatencyMs: 100,
+	}
+	b1, err := json.Marshal(r1)
+	if err != nil {
+		t.Fatalf("Marshal failed: %v", err)
+	}
+	s1 := string(b1)
+	if !strings.Contains(s1, "latency_ms") {
+		t.Error("Expected latency_ms field")
+	}
+
+	// Case 2: Zero Latency (omitted due to omitempty on int)
+	r2 := ResultEnvelope{
+		Result:    200,
+		LatencyMs: 0,
+	}
+	b2, err := json.Marshal(r2)
+	if err != nil {
+		t.Fatalf("Marshal failed: %v", err)
+	}
+	s2 := string(b2)
+	if strings.Contains(s2, "latency_ms") {
+		t.Error("Expected latency_ms to be omitted for 0 value")
+	}
+}

--- a/worker/worker_test.go
+++ b/worker/worker_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/maciekb2/task-manager/pkg/bus"
 	"github.com/maciekb2/task-manager/pkg/flow"
@@ -46,6 +47,24 @@ func TestPerformHttpCheck(t *testing.T) {
 	}
 	if latency < 0 {
 		t.Errorf("expected non-negative latency, got %d", latency)
+	}
+}
+
+func TestPerformHttpCheck_Timeout(t *testing.T) {
+	// Create a slow server
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(100 * time.Millisecond)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	// Context with timeout shorter than server response time
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	defer cancel()
+
+	_, _, err := performHttpCheck(ctx, server.URL, "GET")
+	if err == nil {
+		t.Error("expected error due to timeout, got nil")
 	}
 }
 


### PR DESCRIPTION
Improved test coverage by adding a resilience test for the worker's HTTP check (ensuring timeouts are handled correctly) and adding JSON contract tests for the `pkg/flow` data structures to verify `omitempty` behavior.

Note: The `visualizer` module was identified as missing from CI, but CI configuration was left unchanged per strict user instructions. The new tests are within `pkg` and `worker` modules which are already part of the CI pipeline.

---
*PR created automatically by Jules for task [2321865050695655268](https://jules.google.com/task/2321865050695655268) started by @maciekb2*