### PR TITLE
Improve test coverage for Bus and Server

### DIFF
--- a/pkg/bus/bus.go
+++ b/pkg/bus/bus.go
@@ -344,22 +344,30 @@ func handleFailure(c *Client, msg *nats.Msg, dlqSubject string, retry RetryPolic
 		return
 	}
 
-	if retry.MaxRetries <= 0 {
+	delivered := deliveredCount(msg)
+	action, delay := decideRetryAction(delivered, retry)
+
+	switch action {
+	case "dlq":
 		_ = publishDLQ(c, msg, dlqSubject, err)
 		_ = msg.Ack()
-		return
+	case "retry":
+		_ = nakWithDelay(msg, delay)
+	}
+}
+
+func decideRetryAction(delivered int, retry RetryPolicy) (string, time.Duration) {
+	if retry.MaxRetries <= 0 {
+		return "dlq", 0
 	}
 
-	delivered := deliveredCount(msg)
 	retryAttempt := delivered - 1
 	if retryAttempt >= retry.MaxRetries {
-		_ = publishDLQ(c, msg, dlqSubject, err)
-		_ = msg.Ack()
-		return
+		return "dlq", 0
 	}
 
 	delay := backoffFor(retry, retryAttempt+1)
-	_ = nakWithDelay(msg, delay)
+	return "retry", delay
 }
 
 func publishDLQ(c *Client, msg *nats.Msg, subject string, err error) error {

--- a/pkg/bus/bus_test.go
+++ b/pkg/bus/bus_test.go
@@ -188,12 +188,71 @@ func TestTracePropagation(t *testing.T) {
 	assert.Equal(t, sc.TraceID(), span2.SpanContext().TraceID())
 }
 
-func TestHandleFailure_MaxRetries(t *testing.T) {
-	// Since handleFailure is hard to test without a mocked Client (which needs a real connection usually),
-	// we might skip deep testing of handleFailure here unless we mock the Client methods.
-	// But Client struct has private fields.
-	// However, we can test that logic generally if we could mock.
-	// For now, let's stick to the pure logic functions we already tested.
+func TestDecideRetryAction(t *testing.T) {
+	policy := RetryPolicy{
+		MaxRetries:     3,
+		InitialBackoff: 100 * time.Millisecond,
+		Multiplier:     2.0,
+	}
+
+	tests := []struct {
+		name          string
+		delivered     int
+		retry         RetryPolicy
+		expectedAction string
+		expectedDelay time.Duration
+	}{
+		{
+			name:           "First Delivery (0 retries so far)",
+			delivered:      1,
+			retry:          policy,
+			expectedAction: "retry",
+			expectedDelay:  100 * time.Millisecond,
+		},
+		{
+			name:           "Second Delivery (1 retry so far)",
+			delivered:      2,
+			retry:          policy,
+			expectedAction: "retry",
+			expectedDelay:  200 * time.Millisecond,
+		},
+		{
+			name:           "Third Delivery (2 retries so far)",
+			delivered:      3,
+			retry:          policy,
+			expectedAction: "retry",
+			expectedDelay:  400 * time.Millisecond,
+		},
+		{
+			name:           "Fourth Delivery (3 retries - limit reached)",
+			delivered:      4,
+			retry:          policy,
+			expectedAction: "dlq",
+			expectedDelay:  0,
+		},
+		{
+			name:           "Exceeds Limit",
+			delivered:      5,
+			retry:          policy,
+			expectedAction: "dlq",
+			expectedDelay:  0,
+		},
+		{
+			name:           "No Retries Allowed",
+			delivered:      1,
+			retry:          RetryPolicy{MaxRetries: 0},
+			expectedAction: "dlq",
+			expectedDelay:  0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			action, delay := decideRetryAction(tt.delivered, tt.retry)
+			assert.Equal(t, tt.expectedAction, action)
+			assert.Equal(t, tt.expectedDelay, delay)
+		})
+	}
 }
 
 func TestCloneHeaders(t *testing.T) {

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -267,3 +267,49 @@ func TestStreamTaskStatus_PubSub(t *testing.T) {
 		t.Errorf("expected last status COMPLETED, got %s", lastStatus)
 	}
 }
+
+func TestSubmitTask_DefaultMethod(t *testing.T) {
+	mr, err := miniredis.Run()
+	if err != nil {
+		t.Fatalf("failed to start miniredis: %v", err)
+	}
+	defer mr.Close()
+
+	rdb := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	mockBus := &MockBus{}
+	srv := newServer(rdb, mockBus)
+	ctx := context.Background()
+
+	req := &pb.TaskRequest{
+		TaskDescription: "Default Method Task",
+		Url:             "http://example.com",
+		Method:          "", // Empty method
+	}
+
+	resp, err := srv.SubmitTask(ctx, req)
+	if err != nil {
+		t.Fatalf("SubmitTask failed: %v", err)
+	}
+
+	// Verify Redis content
+	taskKey := "task:" + resp.TaskId
+	val := mr.HGet(taskKey, "method")
+	if val != "GET" {
+		t.Errorf("expected default method 'GET', got '%s'", val)
+	}
+
+	// Verify Bus payload
+	found := false
+	for _, msg := range mockBus.Published {
+		if msg.Subject == bus.SubjectTaskIngest {
+			taskEnv, _ := msg.Payload.(flow.TaskEnvelope)
+			if taskEnv.Method != "GET" {
+				t.Errorf("expected bus payload method 'GET', got '%s'", taskEnv.Method)
+			}
+			found = true
+		}
+	}
+	if !found {
+		t.Error("TaskIngest message not published")
+	}
+}


### PR DESCRIPTION
Evaluated existing tests and identified gaps in `pkg/bus` (retry logic) and `server` (default values).
Refactored `pkg/bus/bus.go` to extract `decideRetryAction` for unit testing.
Added comprehensive tests for retry logic in `pkg/bus/bus_test.go`.
Added integration test for default HTTP method in `server/server_test.go`.
Verified all tests pass and are covered by existing CI.

---
*PR created automatically by Jules for task [10736518526107840763](https://jules.google.com/task/10736518526107840763) started by @maciekb2*