### PR TITLE
Improve test coverage for Server, Worker, and Enricher

### DIFF
--- a/enricher/main_test.go
+++ b/enricher/main_test.go
@@ -73,6 +73,28 @@ func TestHandleEnrich(t *testing.T) {
 			expectedCat:    "low",
 			expectedScore:  12 - 100, // -88
 		},
+		{
+			name:   "Empty URL",
+			method: http.MethodPost,
+			body: enrichRequest{
+				Priority: 0,
+				URL:      "", // len 0
+			},
+			expectedStatus: http.StatusOK,
+			expectedCat:    "low",
+			expectedScore:  0,
+		},
+		{
+			name:   "Long URL",
+			method: http.MethodPost,
+			body: enrichRequest{
+				Priority: 2,
+				URL:      "http://example.com/" + "a_very_long_path_segment_to_increase_score_significantly_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx", // len 19 + 131 = 150
+			},
+			expectedStatus: http.StatusOK,
+			expectedCat:    "high",
+			expectedScore:  175 + 200, // 375
+		},
 	}
 
 	for _, tc := range tests {

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -17,6 +17,7 @@ import (
 // MockBus implements BusClient for testing
 type MockBus struct {
 	Published []PublishedMessage
+	Fail      bool
 }
 
 type PublishedMessage struct {
@@ -25,6 +26,9 @@ type PublishedMessage struct {
 }
 
 func (m *MockBus) PublishJSON(ctx context.Context, subject string, payload any, headers nats.Header, opts ...nats.PubOpt) (*nats.PubAck, error) {
+	if m.Fail {
+		return nil, nats.ErrTimeout
+	}
 	m.Published = append(m.Published, PublishedMessage{Subject: subject, Payload: payload})
 	return &nats.PubAck{}, nil
 }
@@ -157,6 +161,58 @@ func TestSubmitTask_MissingURL(t *testing.T) {
 	_, err = srv.SubmitTask(ctx, req)
 	if err == nil {
 		t.Error("expected error for missing URL, got nil")
+	}
+}
+
+func TestSubmitTask_RedisError(t *testing.T) {
+	mr, err := miniredis.Run()
+	if err != nil {
+		t.Fatalf("failed to start miniredis: %v", err)
+	}
+	defer mr.Close()
+
+	mr.SetError("simulated redis connection lost")
+
+	rdb := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	mockBus := &MockBus{}
+	srv := newServer(rdb, mockBus)
+	ctx := context.Background()
+
+	req := &pb.TaskRequest{
+		TaskDescription: "Redis Fail Task",
+		Priority:        pb.TaskPriority_HIGH,
+		Url:             "http://example.com",
+		Method:          "POST",
+	}
+
+	_, err = srv.SubmitTask(ctx, req)
+	if err == nil {
+		t.Error("expected error when Redis fails, got nil")
+	}
+}
+
+func TestSubmitTask_BusError(t *testing.T) {
+	mr, err := miniredis.Run()
+	if err != nil {
+		t.Fatalf("failed to start miniredis: %v", err)
+	}
+	defer mr.Close()
+
+	rdb := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	mockBus := &MockBus{Fail: true} // Simulate Bus failure
+	srv := newServer(rdb, mockBus)
+	ctx := context.Background()
+
+	req := &pb.TaskRequest{
+		TaskDescription: "Bus Fail Task",
+		Priority:        pb.TaskPriority_HIGH,
+		Url:             "http://example.com",
+		Method:          "POST",
+	}
+
+	_, err = srv.SubmitTask(ctx, req)
+	if err == nil {
+		t.Error("expected error when Bus fails, got nil")
 	}
 }
 

--- a/worker/worker_test.go
+++ b/worker/worker_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/maciekb2/task-manager/pkg/bus"
 	"github.com/maciekb2/task-manager/pkg/flow"
@@ -198,5 +199,22 @@ func TestProcessLoop_BadPayload(t *testing.T) {
 
 	if !foundDeadLetter {
 		t.Error("expected deadletter event for bad payload")
+	}
+}
+
+func TestPerformHttpCheck_Timeout(t *testing.T) {
+	// Server that sleeps longer than our timeout
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(200 * time.Millisecond)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	_, _, err := performHttpCheck(ctx, server.URL, "GET")
+	if err == nil {
+		t.Error("expected timeout error, got nil")
 	}
 }


### PR DESCRIPTION
Added resilience tests for Server (Redis/Bus failure), timeout test for Worker, and edge case tests for Enricher (Empty/Long URL). These tests are automatically integrated into the existing CI/CD pipeline.

---
*PR created automatically by Jules for task [11326438927147698367](https://jules.google.com/task/11326438927147698367) started by @maciekb2*